### PR TITLE
Add allow promotion codes to checkout session request

### DIFF
--- a/lib/messages.g.dart
+++ b/lib/messages.g.dart
@@ -694,6 +694,7 @@ CreateCheckoutSessionRequest _$CreateCheckoutSessionRequestFromJson(
           ? null
           : SubscriptionData.fromJson(
               json['subscription_data'] as Map<String, dynamic>),
+      allowPromotionCodes: json['allow_promotion_codes'] as bool?,
     );
 
 Map<String, dynamic> _$CreateCheckoutSessionRequestToJson(
@@ -724,6 +725,7 @@ Map<String, dynamic> _$CreateCheckoutSessionRequestToJson(
   writeNotNull('tax_id_collection', instance.taxIdCollection?.toJson());
   writeNotNull('payment_intent_data', instance.paymentIntentData?.toJson());
   writeNotNull('subscription_data', instance.subscriptionData?.toJson());
+  writeNotNull('allow_promotion_codes', instance.allowPromotionCodes);
   return val;
 }
 

--- a/lib/src/messages/requests/create_checkout_session.dart
+++ b/lib/src/messages/requests/create_checkout_session.dart
@@ -47,6 +47,10 @@ class CreateCheckoutSessionRequest {
   /// customer’s location and other characteristics.
   final List<PaymentMethodType> paymentMethodTypes;
 
+  /// Enables user redemption of promotion codes on the Checkout Session.
+  @JsonKey(name: 'allow_promotion_codes')
+  final bool? allowPromotionCodes;
+
   /// A unique string to reference the Checkout Session. This can be a customer
   /// ID, a cart ID, or similar, and can be used to reconcile the Session with
   /// your internal systems.
@@ -107,6 +111,7 @@ class CreateCheckoutSessionRequest {
     this.taxIdCollection,
     this.paymentIntentData,
     this.subscriptionData,
+    this.allowPromotionCodes,
   });
 
   factory CreateCheckoutSessionRequest.fromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
## Summary
- add allowPromotionCodes field to CreateCheckoutSessionRequest so promo code support can be enabled when creating Checkout Sessions
- ensure serialized request forwards allow_promotion_codes to the Stripe API

## Testing
- dart test *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbce29fd88328bc9a16314b2c90dc