### PR TITLE
Support checkout.session webhook events

### DIFF
--- a/lib/src/messages/event.dart
+++ b/lib/src/messages/event.dart
@@ -23,8 +23,10 @@ abstract class Event<T extends Message> extends Message {
   });
 
   static T fromJson<T extends Event>(Map<String, dynamic> json) {
-    switch (
-        (json['data']['object']['object'] as String?)?.trim().toLowerCase()) {
+    final object =
+        (json['data']['object']['object'] as String?)?.trim().toLowerCase();
+
+    switch (object?.replaceAll('.', '_')) {
       // case 'balance_transaction':
       //   return BalanceTransactionEvent.fromJson(json) as T;
       case 'charge':

--- a/test/resources/event_message_test.dart
+++ b/test/resources/event_message_test.dart
@@ -15,6 +15,15 @@ void main() {
       expect(message.data.object.email, 'e@test.com');
     });
   });
+
+  group('Event.fromJson', () {
+    test('returns CheckoutSessionEvent for checkout.session payload', () {
+      final message =
+          Event.fromJson(jsonDecode(checkoutSessionCompletedEventObject));
+
+      expect(message, isA<CheckoutSessionEvent>());
+    });
+  });
 }
 
 const eventObject = r'''
@@ -62,4 +71,20 @@ const eventObject = r'''
     "idempotency_key": null
   },
   "type": "customer.created"
+}''';
+
+const checkoutSessionCompletedEventObject = r'''
+{
+  "id": "evt_1ExampleCheckoutSession",
+  "object": "event",
+  "data": {
+    "object": {
+      "id": "cs_test_completed",
+      "object": "checkout.session",
+      "payment_method_types": [
+        "card"
+      ]
+    }
+  },
+  "type": "checkout.session.completed"
 }''';


### PR DESCRIPTION
## Summary
- normalize webhook event object strings before routing to specific event classes
- add a regression test ensuring checkout.session events are parsed into CheckoutSessionEvent

## Testing
- not run (dart command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd233e8188832883c14f94a38ed8a5